### PR TITLE
drop graphql for fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,15 @@ This project is principally intended to be consumed by a Greenwood project as a 
 
 > Check out these links to learn more [about Greenwood](https://www.greenwoodjs.io/about/) as well as the [Quick start guide](https://www.greenwoodjs.io/getting-started/).
 
-To add this plugin to an existing Greenwood project, please do the following:
+To add this plugin to an _existing_ Greenwood project (where `@greenwood/cli` has already been installed), please do the following:
 
 1. Install the plugin and its dependencies
     ```sh
-    $ npm i @greenwood/cli @greenwood/plugin-graphql @greenwood/plugin-import-css greenwood-starter-presentation --save-dev
-    $ npm i lit-element 
+    $ npm install @greenwood/plugin-import-css greenwood-starter-presentation --save-dev
+    $ npm install lit-element 
     ```
 1. Add this plugin and all dependent plugins to your _greenwood.config.js_
     ```js
-    const pluginGraphQL = require('@greenwood/plugin-graphql');
     const pluginImportCss = require('@greenwood/plugin-import-css');
     const pluginThemePresentation = require('greenwood-starter-presentation');
 
@@ -35,7 +34,6 @@ To add this plugin to an existing Greenwood project, please do the following:
       
       plugins: [
         ...pluginImportCss(),
-        ...pluginGraphQL(),
         ...pluginThemePresentation()
       ]
 

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,7 +1,6 @@
 const greenwoodStarterPresentation = require('./index');
 const packageName = require('./package.json').name;
 const path = require('path');
-const pluginGraphQL = require('@greenwood/plugin-graphql');
 const pluginImportCss = require('@greenwood/plugin-import-css');
 const { ResourceInterface } = require('@greenwood/cli/src/lib/resource-interface');
 
@@ -29,7 +28,6 @@ module.exports = {
   
   plugins: [
     ...pluginImportCss(),
-    ...pluginGraphQL(),
     ...greenwoodStarterPresentation({
       __isDevelopment: true
     }),

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "peerDependencies": {
     "@greenwood/cli": "~0.15.0",
-    "@greenwood/plugin-graphql": "~0.15.0",
     "@greenwood/plugin-import-css": "~0.15.0"
   },
   "dependencies": {
@@ -44,7 +43,6 @@
   },
   "devDependencies": {
     "@greenwood/cli": "~0.15.2",
-    "@greenwood/plugin-graphql": "~0.15.2",
     "@greenwood/plugin-import-css": "~0.15.2",
     "eslint": "^7.25.0",
     "rimraf": "^3.0.2",

--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -5,21 +5,14 @@
     <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/slide-list.js"></script>
     <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/slide-viewer.js"></script>
     <script type="module">
-      import client from '@greenwood/plugin-graphql/core/client';
-      import GraphQuery from '@greenwood/plugin-graphql/queries/graph';
-      
-      client.query({
-        query: GraphQuery
-      }).then((response) => {
-        const urlParams = new URLSearchParams(window.location.search);
-        const selectedSlideId = urlParams.get('selectedSlideId');
-        const slides = response.data.graph.filter(slide => slide.id !== 'index');
-        const currentSlideIndex = selectedSlideId ? slides.findIndex(slide => slide.id === selectedSlideId) : 0;
+      fetch('/graph.json')
+        .then((response) => response.json())
+        .then((response) => {
+          const slides = response.filter(slide => slide.id !== 'index');
 
-        document.querySelector('presenter-mode').setAttribute('slides', JSON.stringify(slides));
-        document.querySelector('slide-list').setAttribute('slides', JSON.stringify(slides));
-        document.querySelector('slide-viewer').setAttribute('slide', JSON.stringify(slides[currentSlideIndex]));
-      });
+          document.querySelector('slide-list').setAttribute('slides', JSON.stringify(slides));
+          document.querySelector('slide-viewer').setAttribute('slide', JSON.stringify(slides[0]));
+        });
     </script>
 
     <script>

--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -8,10 +8,14 @@
       fetch('/graph.json')
         .then((response) => response.json())
         .then((response) => {
+          const urlParams = new URLSearchParams(window.location.search);
+          const selectedSlideId = urlParams.get('selectedSlideId');
           const slides = response.filter(slide => slide.id !== 'index');
+          const currentSlideIndex = selectedSlideId ? slides.findIndex(slide => slide.id === selectedSlideId) : 0;
 
+          document.querySelector('presenter-mode').setAttribute('slides', JSON.stringify(slides));
           document.querySelector('slide-list').setAttribute('slides', JSON.stringify(slides));
-          document.querySelector('slide-viewer').setAttribute('slide', JSON.stringify(slides[0]));
+          document.querySelector('slide-viewer').setAttribute('slide', JSON.stringify(slides[currentSlideIndex]));
         });
     </script>
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Coming out of https://github.com/ProjectEvergreen/greenwood/pull/580, it looks like optional pre-rendering will not be compatible with GraphQL, which for this app is probably fine.

## Summary of Changes
1. Replace Apollo for `fetch`
1. Drop **@greenwood/plugin-graphql** related deps

## Question
Or maybe wait until an [SSR solution](https://github.com/ProjectEvergreen/greenwood/discussions/576) is available?