### PR TITLE
remove extra css

### DIFF
--- a/src/templates/theme-top-title-image-left.html
+++ b/src/templates/theme-top-title-image-left.html
@@ -12,11 +12,6 @@
         margin: auto;
       }
 
-      :root: div {
-        padding: 3rem;
-        background-color: pink;
-      }
-
       :root h1 {
         background-color: var(--color-tertiary);
         width: 99%;

--- a/src/templates/theme-top-title.html
+++ b/src/templates/theme-top-title.html
@@ -12,11 +12,6 @@
         margin: auto;
       }
 
-      :root: div {
-        padding: 3rem;
-        background-color: pink;
-      }
-
       :root h1 {
         background-color: var(--color-tertiary);
         width: 99%;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
coming out of #10 / #6

## Summary of Changes
1. It looks like this CSS is not needed, since the syntax isn't valid and thus no styles from it are being used in the theme, so I assume it can be safely deleted

That said, the pink does make a nice accent color against the blues, so I might try and work it in some other way, unless you have some ideas, feel free to modify this!