### PR TITLE
fix inadvertant calls to undefined route

### DIFF
--- a/src/components/slide-viewer.js
+++ b/src/components/slide-viewer.js
@@ -27,7 +27,7 @@ class SlideViewer extends LitElement {
 
   render() {
     const { slide } = this;
-    const url = slide ? slide.route : '';
+    const url = slide && slide.route ? slide.route : '';
 
     return html`
       <iframe src="${url}"></iframe>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

In some cases when loading the `<iframe>`, `slide` would still be an empty object, which means occasionally there would be calls to an `undefined` route, which would cause an error in the console.

![Screen Shot 2021-07-31 at 12 46 09 PM](https://user-images.githubusercontent.com/895923/127753650-650e1698-b3e9-4f1c-903e-c23d164aa3f9.png)
<img width="1527" alt="Screen Shot 2021-07-31 at 12 46 16 PM" src="https://user-images.githubusercontent.com/895923/127753651-e721f380-8a1c-4520-8bd7-12f8d8495070.png">

## Summary of Changes
1. Make sure `slide.route` is also defined before setting the `src` of the `<iframe>`