### PR TITLE
Bug/issue 27 greenwood build and serve workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,23 @@ For those unfamiliar, [CSS Zen Garden](http://www.csszengarden.com/) is a site t
 
 ### Development
 
-To start developing, simply run the `start` command
+To start developing, simply run the `start` script
 
 ```sh
 $ npm start
 ```
 
 This will open a local development server for you at `localhost:1984`.
+
+----
+
+You can preview a production build by using the `serve` script
+
+```sh
+$ npm run serve
+```
+
+You can preview the final site at `localhost:8080`.
 
 ### User Interface
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # greenwood-starter-presentation
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/f1bd02db-7f54-44d1-a3f2-b88b75db8167/deploy-status)](https://app.netlify.com/sites/awesome-bhaskara-b7d76c/deploys)
-
-## Overview
-
 Greenwood plugin and kickstarter repo for creating and authoring a slide deck from markdown, powered by [**GreenwoodJS**](https://www.greenwoodjs.io/)!  ♻️
 
 ![greenwood-starter-presentation](./.github/images/greenwood-starter-presentation.png)
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/f1bd02db-7f54-44d1-a3f2-b88b75db8167/deploy-status)](https://app.netlify.com/sites/awesome-bhaskara-b7d76c/deploys)
 
 ## Installation
 

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -12,7 +12,8 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
   }
 
   async shouldResolve(url) {
-    return Promise.resolve(url.indexOf(`/node_modules/${packageName}/`) >= 0);
+    // eslint-disable-next-line no-underscore-dangle
+    return Promise.resolve((process.env.__GWD_COMMAND__ === ' develop') && url.indexOf(`/node_modules/${packageName}/`) >= 0);
   }
 
   async resolve(url) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenwood-starter-presentation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -19,15 +19,16 @@
   "license": "ISC",
   "scripts": {
     "clean": "rimraf public .greenwood/",
-    "build": "greenwood build",
+    "build": "npm run build:pre && greenwood build",
+    "build:pre": "mkdir -pv ./node_modules/greenwood-starter-presentation/dist && rsync -rv --exclude 'pages/' ./src/ ./node_modules/greenwood-starter-presentation/dist",
     "develop": "greenwood develop",
     "dist": "rsync -rv --exclude 'pages/' src/ dist",
-    "lint": "yarn lint:js && yarn lint:css",
+    "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint \"*.js\" \"./src/**/*.js\"",
     "lint:css": "stylelint \"./src/**/*.js\", \"./src/**/*.css\"",
     "prepublish": "rm -rf dist/ && mkdir dist/ && yarn dist",
-    "serve": "greenwood serve",
-    "start": "yarn develop"
+    "serve": "npm run build:pre && greenwood serve",
+    "start": "npm run develop"
   },
   "peerDependencies": {
     "@greenwood/cli": "~0.15.0",

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   "license": "ISC",
   "scripts": {
     "clean": "rimraf public .greenwood/",
-    "build": "npm run build:pre && greenwood build",
+    "build": "yarn build:pre && greenwood build",
     "build:pre": "mkdir -pv ./node_modules/greenwood-starter-presentation/dist && rsync -rv --exclude 'pages/' ./src/ ./node_modules/greenwood-starter-presentation/dist",
     "develop": "greenwood develop",
     "dist": "rsync -rv --exclude 'pages/' src/ dist",
-    "lint": "npm run lint:js && npm run lint:css",
+    "lint": "yarn lint:js && yarn lint:css",
     "lint:js": "eslint \"*.js\" \"./src/**/*.js\"",
     "lint:css": "stylelint \"./src/**/*.js\", \"./src/**/*.css\"",
     "prepublish": "rm -rf dist/ && mkdir dist/ && yarn dist",
-    "serve": "npm run build:pre && greenwood serve",
-    "start": "npm run develop"
+    "serve": "yarn build:pre && greenwood serve",
+    "start": "yarn develop"
   },
   "peerDependencies": {
     "@greenwood/cli": "~0.15.0",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #27 

## Summary of Changes
1. Add `build:pre` to mock out _node_modules_ structure for Greenwood
1. Made all npm scripts default to npm for portability

## Notes
1. Will add windows support in https://github.com/thescientist13/greenwood-starter-presentation/issues/34
1. Will track the odd issue of needing the space to check the Greenwood command
    ```js
    process.env.__GWD_COMMAND__ === ' develop'
    ```