### PR TITLE
add support for opening links outside of the iframe

### DIFF
--- a/src/components/link-target.js
+++ b/src/components/link-target.js
@@ -1,0 +1,10 @@
+window.addEventListener('DOMContentLoaded', function() {
+  const links = document.querySelectorAll('a');
+
+  links.forEach((link) => {
+    if (link.href && link.href.indexOf('http') === 0) {
+      link.setAttribute('target', '_blank');
+      link.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+});

--- a/src/layouts/page.html
+++ b/src/layouts/page.html
@@ -8,6 +8,8 @@
 
   <body>
     <content-outlet></content-outlet>
+
+    <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
   </body>
 
 </html>

--- a/src/layouts/theme-center-content.html
+++ b/src/layouts/theme-center-content.html
@@ -5,8 +5,6 @@
     <link rel="stylesheet" href="/node_modules/greenwood-starter-presentation/dist/styles/theme.css"></link>
     <link rel="stylesheet" href="/node_modules/greenwood-starter-presentation/dist/styles/main.css"></link>
 
-    <!-- "Full Text Slide" from examples -->
-
     <style>
 
       :root {
@@ -45,6 +43,8 @@
       <content-outlet></content-outlet>
       <hr />
     </div>
+
+    <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
   </body>
 
 </html>

--- a/src/layouts/theme-outline.html
+++ b/src/layouts/theme-outline.html
@@ -16,6 +16,8 @@
 
   <body>
     <content-outlet></content-outlet>
+
+    <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
   </body>
 
 </html>

--- a/src/layouts/theme-statement.html
+++ b/src/layouts/theme-statement.html
@@ -5,8 +5,6 @@
     <link rel="stylesheet" href="/node_modules/greenwood-starter-presentation/dist/styles/theme.css"></link>
     <link rel="stylesheet" href="/node_modules/greenwood-starter-presentation/dist/styles/main.css"></link>
 
-    <!-- "Full Text Slide" from examples -->
-
     <style>
 
       :root {
@@ -43,6 +41,8 @@
       <content-outlet></content-outlet>
       <hr />
     </div>
+    
+    <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
   </body>
 
 </html>

--- a/src/layouts/theme-title.html
+++ b/src/layouts/theme-title.html
@@ -86,6 +86,8 @@
     <div class="container">
       <content-outlet></content-outlet>
     </div>
+
+    <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
   </body>
 
 </html>

--- a/src/layouts/theme-top-title-image-left.html
+++ b/src/layouts/theme-top-title-image-left.html
@@ -65,6 +65,8 @@
       <content-outlet></content-outlet>
       <hr />
     </div>
+
+    <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
   </body>
 
 </html>

--- a/src/layouts/theme-top-title.html
+++ b/src/layouts/theme-top-title.html
@@ -57,6 +57,8 @@
       <content-outlet></content-outlet>
       <hr />
     </div>
+    
+    <script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
   </body>
 
 </html>

--- a/src/pages/slides/7.md
+++ b/src/pages/slides/7.md
@@ -4,9 +4,9 @@ template: theme-top-title-image-left
 
 # Thank You!
 
-@twitter_name
+[@twitter_name](https://www.twitter.com)
 
-facebook
+[facebook](https://www.facebook.com)
 
 email@example.com 
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolve #29 

## Summary of Changes
1. Created a _link-target.js_ script to programmatically open links in a new window and not in the `<iframe>`

## TODO
1. [ ] i think I found a bug in Greenwood where a non `type="module"` `<script>` tag was not getting routed correctly when building.  Should file an issue
```html
<script type="module" src="/node_modules/greenwood-starter-presentation/dist/components/link-target.js"></script>
```
![Screen Shot 2021-08-24 at 9 11 24 PM](https://user-images.githubusercontent.com/895923/130710215-70209a11-fe47-4ff5-b687-283ddb9df538.png)
1. [ ] I should open a new issue to try and incorporate this via markdown instead using [rehype-external-links](https://github.com/rehypejs/rehype-external-links#rehype-external-links), though not sure how to "forward" markdown?  Maybe markdown should be done through a plugin?
1. [ ] Should create an issue to try and wrap all these templates into an _app.html_ since some `<link>` and `<script>` tags are being repeated