### PR TITLE
constrain image size to look good across contexts

### DIFF
--- a/src/layouts/theme-top-title-image-left.html
+++ b/src/layouts/theme-top-title-image-left.html
@@ -50,7 +50,7 @@
 
       :root img {
         position: absolute;
-        width: 40%;
+        width: 35%;
         border: 3px solid var(--color-secondary);
         bottom: 2rem;
         left: 2rem;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #32 

## Summary of Changes
1. Looks pretty good in author mode now (and in presenter mode)
<img width="1600" alt="Screen Shot 2021-08-27 at 11 43 36 AM" src="https://user-images.githubusercontent.com/895923/131155055-57c78593-2e98-4ddc-9572-30953d08e407.png">

> Probably something we should continue to work out along with #7 / #6 