### PR TITLE
upgrade greenwood v0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "lit": "^2.2.3"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.26.0-alpha.1",
-    "@greenwood/plugin-import-css": "~0.26.0-alpha.1",
+    "@greenwood/cli": "~0.26.0",
+    "@greenwood/plugin-import-css": "~0.26.0",
     "eslint": "^8.4.0",
     "rimraf": "^3.0.2",
     "stylelint": "^13.12.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "lit": "^2.2.3"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.25.0",
-    "@greenwood/plugin-import-css": "~0.25.0",
+    "@greenwood/cli": "~0.26.0-alpha.0",
+    "@greenwood/plugin-import-css": "~0.26.0-alpha.0",
     "eslint": "^8.4.0",
     "rimraf": "^3.0.2",
     "stylelint": "^13.12.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "lit": "^2.2.3"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.26.0-alpha.0",
-    "@greenwood/plugin-import-css": "~0.26.0-alpha.0",
+    "@greenwood/cli": "~0.26.0-alpha.1",
+    "@greenwood/plugin-import-css": "~0.26.0-alpha.1",
     "eslint": "^8.4.0",
     "rimraf": "^3.0.2",
     "stylelint": "^13.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,10 +208,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@~0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0.tgz#b0b29513258a3009bbe7e7cca92874a056501fb5"
-  integrity sha512-JIsgYMPTkdNgCN8GtG9Us/g1lw5V4uE9PawszyTPmEav2m0hGAfhLAhhLDAZOgrIm7DUX+k+7oc4nD6Ermt8hA==
+"@greenwood/cli@~0.26.0-alpha.0":
+  version "0.26.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.0.tgz#94274d4d5138f1a93f3c8ab321b2c06350120b22"
+  integrity sha512-Wp/UHtuf+DbHVnSZMycGpUPe9Z1JznEmUfqlSJTCyKtWNv0pUDShNiDhwWEqm9x6aS098IjK6ybsTkJiuLxkoQ==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -237,11 +237,12 @@
     rollup "^2.58.0"
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
+    wc-compiler "~0.3.1"
 
-"@greenwood/plugin-import-css@~0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0.tgz#ec3bb385f4154cff72235321cf5af238c0f69967"
-  integrity sha512-Z4y2wj5KaAVsQ/BiPqim3bGe6iB/n4N/q+pt/kqFDJab5aj7ROhRe4OoMOm5FWOc8g11u56aSw+qVf2oH1u3CA==
+"@greenwood/plugin-import-css@~0.26.0-alpha.0":
+  version "0.26.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.0.tgz#822e54b3f0912271286b8f1ad924109711df1835"
+  integrity sha512-/r4LPng2sMpVnLEP5UZedskwRSlbqxloOEhdENyBhK5BAp1TplhYOB8fk/nEr03TEkQhHgrbjJEXD0Spk9UCFA==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
@@ -418,6 +419,11 @@ acorn-walk@^8.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.2.tgz#d4632bfc63fd93d0f15fd05ea0e984ffd3f5a8c3"
   integrity sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^8.0.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.1.tgz#fb0026885b9ac9f48bac1e185e4af472971149ff"
@@ -427,6 +433,11 @@ acorn@^8.6.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
   integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
+
+acorn@^8.7.0:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -2806,7 +2817,7 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse5@^6.0.0:
+parse5@^6.0.0, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -4201,6 +4212,15 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+wc-compiler@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.3.1.tgz#fedd4249947092ef8d30c41156911a2891c7cef4"
+  integrity sha512-hY72m2EX6WW9k8+kXzrOCxyJetaTRKmGODnW3Ftl2u1d5pOw6mXSZkBI6/5SEw07jbQK/CLs/Tem/SF2PBO0mQ==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
+    parse5 "^6.0.1"
 
 web-namespaces@^1.0.0:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,14 +208,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@~0.26.0-alpha.0":
-  version "0.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.0.tgz#94274d4d5138f1a93f3c8ab321b2c06350120b22"
-  integrity sha512-Wp/UHtuf+DbHVnSZMycGpUPe9Z1JznEmUfqlSJTCyKtWNv0pUDShNiDhwWEqm9x6aS098IjK6ybsTkJiuLxkoQ==
+"@greenwood/cli@~0.26.0-alpha.1":
+  version "0.26.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.1.tgz#1b62c8753f8a95dca4ea02445e370f0cf6b19d56"
+  integrity sha512-T26/cP3cbqC5hUTnnv3O9DFmSfOb2cisrehLi0zof5yMLiL/rHAQbTbCBQ0+xiPPUHwnSKNQRPklHE/yNCTqOQ==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
-    "@webcomponents/webcomponentsjs" "^2.6.0"
     acorn "^8.0.1"
     acorn-walk "^8.0.0"
     commander "^2.20.0"
@@ -237,12 +236,12 @@
     rollup "^2.58.0"
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
-    wc-compiler "~0.3.1"
+    wc-compiler "~0.4.0"
 
-"@greenwood/plugin-import-css@~0.26.0-alpha.0":
-  version "0.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.0.tgz#822e54b3f0912271286b8f1ad924109711df1835"
-  integrity sha512-/r4LPng2sMpVnLEP5UZedskwRSlbqxloOEhdENyBhK5BAp1TplhYOB8fk/nEr03TEkQhHgrbjJEXD0Spk9UCFA==
+"@greenwood/plugin-import-css@~0.26.0-alpha.1":
+  version "0.26.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.1.tgz#27e3f50889a9e880b2c8dc5f6c4cc79f363b0507"
+  integrity sha512-kuaDaFBm6+wHDn9+bB1SYnZuJ+G/Sj5zheMNDB8X5wHv5HqGAfW6Ic/CzW0I6H7gEbFqumYhr/+TKVEKRicXIQ==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
@@ -395,11 +394,6 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
-
-"@webcomponents/webcomponentsjs@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.6.0.tgz#7d1674c40bddf0c6dd974c44ffd34512fe7274ff"
-  integrity sha512-Moog+Smx3ORTbWwuPqoclr+uvfLnciVd6wdCaVscHPrxbmQ/IJKm3wbB7hpzJtXWjAq2l/6QMlO85aZiOdtv5Q==
 
 accepts@^1.3.5:
   version "1.3.7"
@@ -4213,10 +4207,10 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-wc-compiler@~0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.3.1.tgz#fedd4249947092ef8d30c41156911a2891c7cef4"
-  integrity sha512-hY72m2EX6WW9k8+kXzrOCxyJetaTRKmGODnW3Ftl2u1d5pOw6mXSZkBI6/5SEw07jbQK/CLs/Tem/SF2PBO0mQ==
+wc-compiler@~0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.4.1.tgz#7a970760f6decaedfba4d99939d590b43a5ad6a2"
+  integrity sha512-TmjrquaS83Ra+q58L7fhHY2sJPM22oFRbrAnC6Djvq5Ex+qc/iAn/jg4pXRgLzWHlhLwI+6Z8C3sBpINFq0O4Q==
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,10 +208,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@~0.26.0-alpha.1":
-  version "0.26.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.1.tgz#1b62c8753f8a95dca4ea02445e370f0cf6b19d56"
-  integrity sha512-T26/cP3cbqC5hUTnnv3O9DFmSfOb2cisrehLi0zof5yMLiL/rHAQbTbCBQ0+xiPPUHwnSKNQRPklHE/yNCTqOQ==
+"@greenwood/cli@~0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0.tgz#18784c9d435a47a59381a9abf32b2f82652a54b5"
+  integrity sha512-CcxNBxwQGAnu8dnbcsx51EThoHQxr49J0ZCfhXmaB/DvhZvMwXYeJ6ihnWAmSLhlgGr087qJFojyqo3zi3jBtg==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -236,12 +236,12 @@
     rollup "^2.58.0"
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
-    wc-compiler "~0.4.0"
+    wc-compiler "~0.5.0"
 
-"@greenwood/plugin-import-css@~0.26.0-alpha.1":
-  version "0.26.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.1.tgz#27e3f50889a9e880b2c8dc5f6c4cc79f363b0507"
-  integrity sha512-kuaDaFBm6+wHDn9+bB1SYnZuJ+G/Sj5zheMNDB8X5wHv5HqGAfW6Ic/CzW0I6H7gEbFqumYhr/+TKVEKRicXIQ==
+"@greenwood/plugin-import-css@~0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0.tgz#64912baae0a069845ebfed6aa18398f8b9310ddf"
+  integrity sha512-cuJDa8klePyzaMK/2mHyzhEgFanp8f7TGLBGSrmXwqTe8JvHdztb6jhMO0v8o16p4mmwgsM3fzUO9XVGIKEBNw==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
@@ -4207,10 +4207,10 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-wc-compiler@~0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.4.1.tgz#7a970760f6decaedfba4d99939d590b43a5ad6a2"
-  integrity sha512-TmjrquaS83Ra+q58L7fhHY2sJPM22oFRbrAnC6Djvq5Ex+qc/iAn/jg4pXRgLzWHlhLwI+6Z8C3sBpINFq0O4Q==
+wc-compiler@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.5.0.tgz#869739ba765e41ac699b08a5991c52231ef2fbe0"
+  integrity sha512-ScHbrtd81cvMEg8tn7L/iSc1WhckNKIB77VGhZYxMNELHmgQdMuC/r36E/LhAHdqAJYxi4y77DXmU56BZzeBng==
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"


### PR DESCRIPTION
## Related Issue
Greenwood [**v0.26.0**](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.26.0) release

## Summary of Changes
1. Upgrade latest version

---

Not sure if there are technical directions this release line could bring, per #19 