### PR TITLE
bump greenwood cli peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "start": "npm run develop"
   },
   "peerDependencies": {
-    "@greenwood/cli": "~0.28.2"
+    "@greenwood/cli": "~0.29.0"
   },
   "devDependencies": {
     "@greenwood/cli": "~0.29.0",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#66 

## Summary of Changes
1. Given the hard dependency on this new version of Greenwood, should have bumped to set the new minimum `peerDependency` version for **@greenwood/cli** package