### PR TITLE
bug/restore import-css plugin for theme cascade regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,18 @@ To add this plugin to an _existing_ Greenwood project (where `@greenwood/cli` ha
 
 1. Install the plugin as a dev dependency
     ```sh
-    $ npm install greenwood-starter-presentation --save-dev
+    $ npm i greenwood-starter-presentation --save-dev --legacy-peer-deps
     ```
-1. Add this plugin and all dependent plugins to your _greenwood.config.js_
+1. Add this and Greenwood's Import CSS plugin to your _greenwood.config.js_
     ```js
+    import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
     import { greenwoodThemeStarterPresentation } from 'greenwood-starter-presentation';
 
     export default {
       // ...
       
       plugins: [
+        greenwoodPluginImportCss(),
         greenwoodThemeStarterPresentation()
       ]
 

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { greenwoodThemeStarterPresentation } from './index.js';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
+import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
 
 const packageName = JSON.parse(fs.readFileSync(path.join(process.cwd(), './package.json'), 'utf-8')).name;
 
@@ -27,6 +28,7 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
 
 export default {  
   plugins: [
+    greenwoodPluginImportCss(),
     greenwoodThemeStarterPresentation({
       __isDevelopment: true
     }),

--- a/package.json
+++ b/package.json
@@ -41,8 +41,12 @@
   "peerDependencies": {
     "@greenwood/cli": "~0.29.0"
   },
+  "dependencies": {
+    "@greenwood/plugin-import-css": "~0.29.0"
+  },
   "devDependencies": {
     "@greenwood/cli": "~0.29.0",
+    "@greenwood/plugin-import-css": "~0.29.0",
     "eslint": "^8.4.0",
     "rimraf": "^3.0.2",
     "stylelint": "^13.12.0",

--- a/src/components/presenter-mode.js
+++ b/src/components/presenter-mode.js
@@ -1,7 +1,11 @@
+import themeCss from '../styles/theme.css?type=css';
+
 const template = document.createElement('template');
 
 template.innerHTML = `
   <style>
+    ${themeCss}
+
     .fullscreen-container {
       display: none;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,6 +237,11 @@
     unified "^9.2.0"
     wc-compiler "~0.9.0"
 
+"@greenwood/plugin-import-css@~0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.29.0.tgz#bed9959e80d84f43ee28cc5ca6de6209691427fc"
+  integrity sha512-2FMk3qs8umOuR4bb4xSuW1bRGV1Pk1QS1QY6sk5BNhOIO5+ZphtuIrVTJUcfxHzLw4BBOG4Xws6LJCs5XfNfjw==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #69 

## Summary of Changes
1. Restore **@greenwood/plugin-import-css** as a top level dependency
1. Update README.md